### PR TITLE
Fix memory leak when browser is disabled

### DIFF
--- a/HtmlRenderer/Renderer.cs
+++ b/HtmlRenderer/Renderer.cs
@@ -190,6 +190,7 @@ namespace RainbowMage.HtmlRenderer
             {
                 EndRender();
             }
+            InitBrowser();
             var cefWindowInfo = CreateWindowInfo();
             _isWindowless = cefWindowInfo.WindowlessRenderingEnabled;
 
@@ -210,7 +211,6 @@ namespace RainbowMage.HtmlRenderer
                 _browser.GetBrowserHost().CloseBrowser(true);
                 _browser.Dispose();
 
-                InitBrowser();
                 isStopRender = true;
             }
         }

--- a/HtmlRenderer/Renderer.cs
+++ b/HtmlRenderer/Renderer.cs
@@ -189,8 +189,8 @@ namespace RainbowMage.HtmlRenderer
             if (!isStopRender)
             {
                 EndRender();
+                InitBrowser();
             }
-            InitBrowser();
             var cefWindowInfo = CreateWindowInfo();
             _isWindowless = cefWindowInfo.WindowlessRenderingEnabled;
 

--- a/HtmlRenderer/Renderer.cs
+++ b/HtmlRenderer/Renderer.cs
@@ -28,6 +28,7 @@ namespace RainbowMage.HtmlRenderer
 
         private BrowserWrapper _browser;
         private bool _isWindowless;
+        private bool isStopRender = false;
         protected IRenderTarget _target;
         private object _api;
         private Func<int, int, bool> _ctxMenuCallback = null;
@@ -185,8 +186,10 @@ namespace RainbowMage.HtmlRenderer
 
         public void BeginRender()
         {
-            EndRender();
-
+            if (!isStopRender)
+            {
+                EndRender();
+            }
             var cefWindowInfo = CreateWindowInfo();
             _isWindowless = cefWindowInfo.WindowlessRenderingEnabled;
 
@@ -196,6 +199,7 @@ namespace RainbowMage.HtmlRenderer
 
             cefBrowserSettings.Dispose();
             cefWindowInfo.Dispose();
+            isStopRender = false;
         }
 
         public void EndRender()
@@ -207,6 +211,7 @@ namespace RainbowMage.HtmlRenderer
                 _browser.Dispose();
 
                 InitBrowser();
+                isStopRender = true;
             }
         }
 
@@ -559,7 +564,10 @@ MaxUploadsPerDay=0
             }
             else
             {
-                this.scriptQueue.Add(script);
+                if (!isStopRender)
+                {
+                    this.scriptQueue.Add(script);
+                }
             }
         }
 

--- a/HtmlRenderer/Renderer.cs
+++ b/HtmlRenderer/Renderer.cs
@@ -28,7 +28,7 @@ namespace RainbowMage.HtmlRenderer
 
         private BrowserWrapper _browser;
         private bool _isWindowless;
-        private bool isStopRender = true;
+        private bool _isRendering = false;
         protected IRenderTarget _target;
         private object _api;
         private Func<int, int, bool> _ctxMenuCallback = null;
@@ -186,8 +186,10 @@ namespace RainbowMage.HtmlRenderer
 
         public void BeginRender()
         {
-
-            EndRender();
+            if (_isRendering)
+            {
+                EndRender();
+            }
             var cefWindowInfo = CreateWindowInfo();
             _isWindowless = cefWindowInfo.WindowlessRenderingEnabled;
 
@@ -197,18 +199,19 @@ namespace RainbowMage.HtmlRenderer
 
             cefBrowserSettings.Dispose();
             cefWindowInfo.Dispose();
-            isStopRender = false;
+            _isRendering = true;
         }
 
         public void EndRender()
         {
+            _isRendering = false;
             if (_browser != null && _browser.IsBrowserInitialized)
             {
                 _browser.GetBrowser().CloseBrowser(true);
                 _browser.GetBrowserHost().CloseBrowser(true);
                 _browser.Dispose();
+
                 InitBrowser();
-                isStopRender = true;
             }
         }
 
@@ -555,7 +558,7 @@ MaxUploadsPerDay=0
 
         public void ExecuteScript(string script)
         {
-            if (!isStopRender)
+            if (_isRendering)
             {
                 if (_browser != null && _browser.IsBrowserInitialized)
                 {

--- a/HtmlRenderer/Renderer.cs
+++ b/HtmlRenderer/Renderer.cs
@@ -186,11 +186,8 @@ namespace RainbowMage.HtmlRenderer
 
         public void BeginRender()
         {
-            if (!isStopRender)
-            {
-                EndRender();
-                InitBrowser();
-            }
+
+            EndRender();
             var cefWindowInfo = CreateWindowInfo();
             _isWindowless = cefWindowInfo.WindowlessRenderingEnabled;
 
@@ -210,7 +207,7 @@ namespace RainbowMage.HtmlRenderer
                 _browser.GetBrowser().CloseBrowser(true);
                 _browser.GetBrowserHost().CloseBrowser(true);
                 _browser.Dispose();
-
+                InitBrowser();
                 isStopRender = true;
             }
         }
@@ -558,13 +555,13 @@ MaxUploadsPerDay=0
 
         public void ExecuteScript(string script)
         {
-            if (_browser != null && _browser.IsBrowserInitialized)
+            if (!isStopRender)
             {
-                _browser.GetMainFrame().ExecuteJavaScriptAsync(script, "injected");
-            }
-            else
-            {
-                if (!isStopRender)
+                if (_browser != null && _browser.IsBrowserInitialized)
+                {
+                    _browser.GetMainFrame().ExecuteJavaScriptAsync(script, "injected");
+                }
+                else
                 {
                     this.scriptQueue.Add(script);
                 }

--- a/HtmlRenderer/Renderer.cs
+++ b/HtmlRenderer/Renderer.cs
@@ -28,7 +28,7 @@ namespace RainbowMage.HtmlRenderer
 
         private BrowserWrapper _browser;
         private bool _isWindowless;
-        private bool isStopRender = false;
+        private bool isStopRender = true;
         protected IRenderTarget _target;
         private object _api;
         private Func<int, int, bool> _ctxMenuCallback = null;

--- a/HtmlRenderer/Renderer.cs
+++ b/HtmlRenderer/Renderer.cs
@@ -210,6 +210,7 @@ namespace RainbowMage.HtmlRenderer
                 _browser.GetBrowser().CloseBrowser(true);
                 _browser.GetBrowserHost().CloseBrowser(true);
                 _browser.Dispose();
+                scriptQueue.Clear();
 
                 InitBrowser();
             }

--- a/HtmlRenderer/Renderer.cs
+++ b/HtmlRenderer/Renderer.cs
@@ -210,10 +210,10 @@ namespace RainbowMage.HtmlRenderer
                 _browser.GetBrowser().CloseBrowser(true);
                 _browser.GetBrowserHost().CloseBrowser(true);
                 _browser.Dispose();
-                scriptQueue.Clear();
 
                 InitBrowser();
             }
+            scriptQueue.Clear();
         }
 
         public void SetMaxFramerate(int fps)

--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -323,8 +323,8 @@ namespace RainbowMage.OverlayPlugin.EventSources
                     {
                         importedLogs.Add(args.originalLogLine);
                     }
-                    return;
                 }
+                return;
             }
 
             try

--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -317,11 +317,14 @@ namespace RainbowMage.OverlayPlugin.EventSources
         {
             if (isImport)
             {
-                lock (importedLogs)
+                if (HasSubscriber(ImportedLogLinesEvent))
                 {
-                    importedLogs.Add(args.originalLogLine);
+                    lock (importedLogs)
+                    {
+                        importedLogs.Add(args.originalLogLine);
+                    }
+                    return;
                 }
-                return;
             }
 
             try
@@ -547,27 +550,21 @@ namespace RainbowMage.OverlayPlugin.EventSources
                 DispatchEvent(this.CreateCombatData());
             }
 
-            if (importing && HasSubscriber(ImportedLogLinesEvent))
+            if (HasSubscriber(ImportedLogLinesEvent))
             {
-                List<string> logs = null;
-
                 lock (importedLogs)
                 {
                     if (importedLogs.Count > 0)
                     {
-                        logs = importedLogs;
+                        DispatchEvent(JObject.FromObject(new
+                        {
+                            type = ImportedLogLinesEvent,
+                            logLines = importedLogs
+                        }));
                         importedLogs = new List<string>();
                     }
                 }
-
-                if (logs != null)
-                {
-                    DispatchEvent(JObject.FromObject(new
-                    {
-                        type = ImportedLogLinesEvent,
-                        logLines = logs
-                    }));
-                }
+              
             }
 
             if (ffxivPluginPresent)

--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -552,19 +552,23 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
             if (HasSubscriber(ImportedLogLinesEvent))
             {
+                List<string> logs = null;
                 lock (importedLogs)
                 {
                     if (importedLogs.Count > 0)
                     {
-                        DispatchEvent(JObject.FromObject(new
-                        {
-                            type = ImportedLogLinesEvent,
-                            logLines = importedLogs
-                        }));
+                        logs = importedLogs;
                         importedLogs = new List<string>();
                     }
                 }
-              
+                if (logs != null)
+                {
+                    DispatchEvent(JObject.FromObject(new
+                    {
+                        type = ImportedLogLinesEvent,
+                        logLines = logs
+                    }));
+                }
             }
 
             if (ffxivPluginPresent)


### PR DESCRIPTION
Leak1: Since not consumer (ImportedLogLinesEvent Subscriber) there, the imported logs will persist in memory
Leak2: Since the overlay was disabled, the script (for example, the log line when combating) added to `scriptQueue` will never be executed unless enable it again.