### PR TITLE
fix: Add lock for processHandle to fix concurrent issue

### DIFF
--- a/OverlayPlugin.Core/MemoryProcessors/FFXIVMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/FFXIVMemory.cs
@@ -11,9 +11,10 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
         public event EventHandler OnProcessChange;
 
         private ILogger logger;
-        private Process process;
-        private IntPtr processHandle;
+        private volatile Process process;
+        private volatile IntPtr processHandle;
         private FFXIVRepository repository;
+        private Object mutex = new Object();
 
         private bool hasLoggedDx9 = false;
 
@@ -27,40 +28,45 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
 
         private void UpdateProcess(Process proc)
         {
-            if (processHandle != IntPtr.Zero)
+            lock (mutex)
             {
-                CloseProcessHandle();
-            }
-
-            if (proc == null || proc.HasExited)
-                return;
-
-            if (proc.ProcessName == "ffxiv")
-            {
-                if (!hasLoggedDx9)
+                if (processHandle != IntPtr.Zero)
                 {
-                    hasLoggedDx9 = true;
-                    logger.Log(LogLevel.Error, "{0}", "不支持 DX9 模式启动的游戏，请参考 https://www.yuque.com/ffcafe/act/dx11/ 解决");
-                    MessageBox.Show("现在 ACT 的部分功能不支持 DX9 启动的游戏。\r\n请在游戏启动器器设置里选择以 DX11 模式运行游戏。", "兼容提示", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    CloseProcessHandle();
                 }
-                return;
-            }
-            else if (proc.ProcessName != "ffxiv_dx11")
-            {
-                logger.Log(LogLevel.Error, "{0}", "Unknown ffxiv process.");
-                return;
-            }
 
-            try {
-                process = proc;
-                processHandle = NativeMethods.OpenProcess(ProcessAccessFlags.VirtualMemoryRead, false, proc.Id);
-                logger.Log(LogLevel.Info, "游戏进程：{0}，来源：解析插件订阅", proc.Id);
-            } catch (Exception e)
-            {
-                logger.Log(LogLevel.Error, "Failed to open FFXIV process: {0}", e);
+                if (proc == null || proc.HasExited)
+                    return;
 
-                process = null;
-                processHandle = IntPtr.Zero;
+                if (proc.ProcessName == "ffxiv")
+                {
+                    if (!hasLoggedDx9)
+                    {
+                        hasLoggedDx9 = true;
+                        logger.Log(LogLevel.Error, "{0}", "不支持 DX9 模式启动的游戏，请参考 https://www.yuque.com/ffcafe/act/dx11/ 解决");
+                        MessageBox.Show("现在 ACT 的部分功能不支持 DX9 启动的游戏。\r\n请在游戏启动器器设置里选择以 DX11 模式运行游戏。", "兼容提示", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
+                    return;
+                }
+                else if (proc.ProcessName != "ffxiv_dx11")
+                {
+                    logger.Log(LogLevel.Error, "{0}", "Unknown ffxiv process.");
+                    return;
+                }
+
+                try
+                {
+                    process = proc;
+                    processHandle = NativeMethods.OpenProcess(ProcessAccessFlags.VirtualMemoryRead, false, proc.Id);
+                    logger.Log(LogLevel.Info, "游戏进程：{0}，来源：解析插件订阅", proc.Id);
+                }
+                catch (Exception e)
+                {
+                    logger.Log(LogLevel.Error, "Failed to open FFXIV process: {0}", e);
+
+                    process = null;
+                    processHandle = IntPtr.Zero;
+                }
             }
 
             OnProcessChange?.Invoke(this, null);
@@ -74,7 +80,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                 {
                     // The current handle is still valid.
                     return;
-                } else
+                }
+                else
                 {
                     CloseProcessHandle();
                 }
@@ -113,23 +120,26 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
 
         public bool IsValid()
         {
-            if (process != null && process.HasExited)
+            lock (mutex)
             {
-                CloseProcessHandle();
+                if (process != null && process.HasExited)
+                {
+                    CloseProcessHandle();
+                    OnProcessChange?.Invoke(this, null);
+                }
+
+                if (processHandle != IntPtr.Zero)
+                    return true;
+
+                FindProcess();
+                if (processHandle == IntPtr.Zero || process == null || process.HasExited)
+                {
+                    return false;
+                }
+
                 OnProcessChange?.Invoke(this, null);
-            }
-            
-            if (processHandle != IntPtr.Zero)
                 return true;
-
-            FindProcess();
-            if (processHandle == IntPtr.Zero || process == null || process.HasExited)
-            {
-                return false;
             }
-
-            OnProcessChange?.Invoke(this, null);
-            return true;
         }
 
         public unsafe static string GetStringFromBytes(byte* source, int size)
@@ -303,101 +313,104 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
         /// <returns>A list of pointers read relative to the end of strings in the process memory matching the |pattern|.</returns>
         public List<IntPtr> SigScan(string pattern, int offset, bool rip_addressing)
         {
-            List<IntPtr> matches_list = new List<IntPtr>();
-
-            if (pattern == null || pattern.Length % 2 != 0)
+            lock (mutex)
             {
-                logger.Log(LogLevel.Error, "Invalid signature pattern: {0}", pattern);
-                return matches_list;
-            }
+                List<IntPtr> matches_list = new List<IntPtr>();
 
-            // Build a byte array from the pattern string. "??" is a wildcard
-            // represented as null in the array.
-            byte?[] pattern_array = new byte?[pattern.Length / 2];
-            for (int i = 0; i < pattern.Length / 2; i++)
-            {
-                string text = pattern.Substring(i * 2, 2);
-                if (text == "??")
+                if (pattern == null || pattern.Length % 2 != 0)
                 {
-                    pattern_array[i] = null;
+                    logger.Log(LogLevel.Error, "Invalid signature pattern: {0}", pattern);
+                    return matches_list;
                 }
-                else
+
+                // Build a byte array from the pattern string. "??" is a wildcard
+                // represented as null in the array.
+                byte?[] pattern_array = new byte?[pattern.Length / 2];
+                for (int i = 0; i < pattern.Length / 2; i++)
                 {
-                    pattern_array[i] = new byte?(Convert.ToByte(text, 16));
-                }
-            }
-
-            // Read this many bytes at a time. This needs to be a 32bit number as BitConverter pulls
-            // from a 32bit offset into the array that we read from the process.
-            const Int32 kMaxReadSize = 65536;
-
-            int module_memory_size = process.MainModule.ModuleMemorySize;
-            IntPtr process_start_addr = process.MainModule.BaseAddress;
-            IntPtr process_end_addr = IntPtr.Add(process_start_addr, module_memory_size);
-
-            IntPtr read_start_addr = process_start_addr;
-            byte[] read_buffer = new byte[kMaxReadSize];
-            while (read_start_addr.ToInt64() < process_end_addr.ToInt64())
-            {
-                // Determine how much to read without going off the end of the process.
-                Int64 bytes_left = process_end_addr.ToInt64() - read_start_addr.ToInt64();
-                IntPtr read_size = (IntPtr)Math.Min(bytes_left, kMaxReadSize);
-
-                IntPtr num_bytes_read = IntPtr.Zero;
-                if (NativeMethods.ReadProcessMemory(processHandle, read_start_addr, read_buffer, read_size, ref num_bytes_read))
-                {
-                    int max_search_offset = num_bytes_read.ToInt32() - pattern_array.Length - Math.Max(0, offset);
-                    // With RIP we will read a 4byte pointer at the |offset|, else we read an 8byte pointer. Either
-                    // way we can't find a pattern such that the pointer we want to read is off the end of the buffer.
-                    if (rip_addressing)
-                        max_search_offset -= 4;  //  + 1L; ?
-                    else
-                        max_search_offset -= 8;
-
-                    for (int search_offset = 0; (Int64)search_offset < max_search_offset; ++search_offset)
+                    string text = pattern.Substring(i * 2, 2);
+                    if (text == "??")
                     {
-                        bool found_pattern = true;
-                        for (int pattern_i = 0; pattern_i < pattern_array.Length; pattern_i++)
-                        {
-                            // Wildcard always matches, otherwise compare to the read_buffer.
-                            byte? pattern_byte = pattern_array[pattern_i];
-                            if (pattern_byte.HasValue &&
-                                pattern_byte.Value != read_buffer[search_offset + pattern_i])
-                            {
-                                found_pattern = false;
-                                break;
-                            }
-                        }
-                        if (found_pattern)
-                        {
-                            IntPtr pointer;
-                            if (rip_addressing)
-                            {
-                                Int32 rip_ptr_offset = BitConverter.ToInt32(read_buffer, search_offset + pattern_array.Length + offset);
-                                Int64 pattern_start_game_addr = read_start_addr.ToInt64() + search_offset;
-                                Int64 pointer_offset_from_pattern_start = pattern_array.Length + offset;
-                                Int64 rip_ptr_base = pattern_start_game_addr + pointer_offset_from_pattern_start + 4;
-                                // In RIP addressing, the pointer from the executable is 32bits which we stored as |rip_ptr_offset|. The pointer
-                                // is then added to the address of the byte following the pointer, making it relative to that address, which we
-                                // stored as |rip_ptr_base|.
-                                pointer = new IntPtr((Int64)rip_ptr_offset + rip_ptr_base);
-                            }
-                            else
-                            {
-                                // In normal addressing, the 64bits found with the pattern are the absolute pointer.
-                                pointer = new IntPtr(BitConverter.ToInt64(read_buffer, search_offset + pattern_array.Length + offset));
-                            }
-                            matches_list.Add(pointer);
-                        }
+                        pattern_array[i] = null;
+                    }
+                    else
+                    {
+                        pattern_array[i] = new byte?(Convert.ToByte(text, 16));
                     }
                 }
 
-                // Move to the next contiguous buffer to read.
-                // TODO: If the pattern lies across 2 buffers, then it would not be found.
-                read_start_addr = IntPtr.Add(read_start_addr, kMaxReadSize);
-            }
+                // Read this many bytes at a time. This needs to be a 32bit number as BitConverter pulls
+                // from a 32bit offset into the array that we read from the process.
+                const Int32 kMaxReadSize = 65536;
 
-            return matches_list;
+                int module_memory_size = process.MainModule.ModuleMemorySize;
+                IntPtr process_start_addr = process.MainModule.BaseAddress;
+                IntPtr process_end_addr = IntPtr.Add(process_start_addr, module_memory_size);
+
+                IntPtr read_start_addr = process_start_addr;
+                byte[] read_buffer = new byte[kMaxReadSize];
+                while (read_start_addr.ToInt64() < process_end_addr.ToInt64())
+                {
+                    // Determine how much to read without going off the end of the process.
+                    Int64 bytes_left = process_end_addr.ToInt64() - read_start_addr.ToInt64();
+                    IntPtr read_size = (IntPtr)Math.Min(bytes_left, kMaxReadSize);
+
+                    IntPtr num_bytes_read = IntPtr.Zero;
+                    if (NativeMethods.ReadProcessMemory(processHandle, read_start_addr, read_buffer, read_size, ref num_bytes_read))
+                    {
+                        int max_search_offset = num_bytes_read.ToInt32() - pattern_array.Length - Math.Max(0, offset);
+                        // With RIP we will read a 4byte pointer at the |offset|, else we read an 8byte pointer. Either
+                        // way we can't find a pattern such that the pointer we want to read is off the end of the buffer.
+                        if (rip_addressing)
+                            max_search_offset -= 4;  //  + 1L; ?
+                        else
+                            max_search_offset -= 8;
+
+                        for (int search_offset = 0; (Int64)search_offset < max_search_offset; ++search_offset)
+                        {
+                            bool found_pattern = true;
+                            for (int pattern_i = 0; pattern_i < pattern_array.Length; pattern_i++)
+                            {
+                                // Wildcard always matches, otherwise compare to the read_buffer.
+                                byte? pattern_byte = pattern_array[pattern_i];
+                                if (pattern_byte.HasValue &&
+                                    pattern_byte.Value != read_buffer[search_offset + pattern_i])
+                                {
+                                    found_pattern = false;
+                                    break;
+                                }
+                            }
+                            if (found_pattern)
+                            {
+                                IntPtr pointer;
+                                if (rip_addressing)
+                                {
+                                    Int32 rip_ptr_offset = BitConverter.ToInt32(read_buffer, search_offset + pattern_array.Length + offset);
+                                    Int64 pattern_start_game_addr = read_start_addr.ToInt64() + search_offset;
+                                    Int64 pointer_offset_from_pattern_start = pattern_array.Length + offset;
+                                    Int64 rip_ptr_base = pattern_start_game_addr + pointer_offset_from_pattern_start + 4;
+                                    // In RIP addressing, the pointer from the executable is 32bits which we stored as |rip_ptr_offset|. The pointer
+                                    // is then added to the address of the byte following the pointer, making it relative to that address, which we
+                                    // stored as |rip_ptr_base|.
+                                    pointer = new IntPtr((Int64)rip_ptr_offset + rip_ptr_base);
+                                }
+                                else
+                                {
+                                    // In normal addressing, the 64bits found with the pattern are the absolute pointer.
+                                    pointer = new IntPtr(BitConverter.ToInt64(read_buffer, search_offset + pattern_array.Length + offset));
+                                }
+                                matches_list.Add(pointer);
+                            }
+                        }
+                    }
+
+                    // Move to the next contiguous buffer to read.
+                    // TODO: If the pattern lies across 2 buffers, then it would not be found.
+                    read_start_addr = IntPtr.Add(read_start_addr, kMaxReadSize);
+                }
+
+                return matches_list;
+            }
         }
     }
 }

--- a/OverlayPlugin.Core/MemoryProcessors/FFXIVMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/FFXIVMemory.cs
@@ -272,7 +272,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
         public byte[] Read8(IntPtr addr, int count)
         {
             _processLock.EnterReadLock();
-            try{
+            try
+            {
                 int buffer_len = 1 * count;
                 var buffer = new byte[buffer_len];
                 var bytes_read = IntPtr.Zero;
@@ -373,7 +374,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
         public List<IntPtr> SigScan(string pattern, int offset, bool rip_addressing)
         {
             _processLock.EnterReadLock();
-            try{
+            try
+            {
                 List<IntPtr> matches_list = new List<IntPtr>();
 
                 if (pattern == null || pattern.Length % 2 != 0)
@@ -472,7 +474,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             }
             finally
             {
-                _processLock.EnterReadLock();
+                _processLock.ExitReadLock();
             }
         }
     }

--- a/OverlayPlugin.Core/MemoryProcessors/FFXIVMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/FFXIVMemory.cs
@@ -7,7 +7,7 @@ using System.Windows.Forms;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors
 {
-    public class FFXIVMemory
+    public class FFXIVMemory : IDisposable
     {
         public event EventHandler OnProcessChange;
 
@@ -20,6 +20,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
         private readonly ReaderWriterLockSlim _processLock = new ReaderWriterLockSlim();
 
         private bool hasLoggedDx9 = false;
+        private bool hasDisposed;
 
         public FFXIVMemory(TinyIoCContainer container)
         {
@@ -476,6 +477,26 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             {
                 _processLock.ExitReadLock();
             }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!hasDisposed)
+            {
+                if (disposing)
+                {
+                    _processLock.Dispose();
+                }
+
+                hasDisposed = true;
+            }
+        }
+
+        void IDisposable.Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/OverlayPlugin.Core/MemoryProcessors/FFXIVMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/FFXIVMemory.cs
@@ -10,11 +10,11 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
     {
         public event EventHandler OnProcessChange;
 
-        private ILogger logger;
+        private readonly ILogger logger;
         private volatile Process process;
         private volatile IntPtr processHandle;
-        private FFXIVRepository repository;
-        private Object mutex = new Object();
+        private readonly FFXIVRepository repository;
+        private readonly Object _mutex = new Object();
 
         private bool hasLoggedDx9 = false;
 
@@ -28,7 +28,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
 
         private void UpdateProcess(Process proc)
         {
-            lock (mutex)
+            lock (_mutex)
             {
                 if (processHandle != IntPtr.Zero)
                 {
@@ -120,7 +120,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
 
         public bool IsValid()
         {
-            lock (mutex)
+            lock (_mutex)
             {
                 if (process != null && process.HasExited)
                 {
@@ -313,7 +313,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
         /// <returns>A list of pointers read relative to the end of strings in the process memory matching the |pattern|.</returns>
         public List<IntPtr> SigScan(string pattern, int offset, bool rip_addressing)
         {
-            lock (mutex)
+            lock (_mutex)
             {
                 List<IntPtr> matches_list = new List<IntPtr>();
 


### PR DESCRIPTION
因为对C#的锁不熟，姑且用了lock语句和 `_mutex` 变量来管理 `processHandle` 和 `process` 变量的锁，如果有建议欢迎提出（
修复了下述截图的问题，来源ACT国服整合支持群（163386335）：
![TIM图片20211016193211](https://user-images.githubusercontent.com/20417547/137585751-aef9e3d7-6039-4dbf-8035-a0491dd60674.png)
