### PR TITLE
Improve cef version checking

### DIFF
--- a/OverlayPlugin.Core/PluginMain.cs
+++ b/OverlayPlugin.Core/PluginMain.cs
@@ -145,6 +145,11 @@ namespace RainbowMage.OverlayPlugin
                 catch (Exception e)
                 {
                     _logger.Log(LogLevel.Error, "InitPlugin: {0}", e);
+                    if (e is TypeLoadException)
+                    {
+                        //Let upper invoker handle this exception
+                        throw new TypeLoadException("CefSharp Load Failed", e);
+                    }
                 }
 
 #if DEBUG

--- a/OverlayPlugin.Updater/CefInstaller.cs
+++ b/OverlayPlugin.Updater/CefInstaller.cs
@@ -73,7 +73,18 @@ namespace RainbowMage.OverlayPlugin.Updater
                     var itsFine = true;
                     foreach (var name in importantFiles)
                     {
-                        if (!File.Exists(Path.Combine(cefPath, name)))
+                        var filePath = Path.Combine(cefPath, name);
+                        if (!File.Exists(filePath))
+                        {
+                            itsFine = false;
+                            break;
+                        }
+                        else if (
+                            //Check cef sharp version
+                            (name.StartsWith("CefSharp") && !FileVersionInfo.GetVersionInfo(filePath).FileVersion.Equals(CEF_VERSION))
+                            //Check cef redist version
+                            || (name.Equals("libcef.dll") && !FileVersionInfo.GetVersionInfo(filePath).FileVersion.Equals(CEF_REDIST_VERSION))
+                            )
                         {
                             itsFine = false;
                             break;
@@ -128,15 +139,17 @@ namespace RainbowMage.OverlayPlugin.Updater
                     var installer = new Installer(destDir, tmpName);
                     try
                     {
-                        bool result= await Installer.DownloadAndExtractTo(installer, GetNupkgUrl(packageName, version, i), tmpName, destDir, archiveDir, message, archiveDir2);
+                        bool result = await Installer.DownloadAndExtractTo(installer, GetNupkgUrl(packageName, version, i), tmpName, destDir, archiveDir, message, archiveDir2);
                         if (result)
                         {
 
-                            failedInstaller.ForEach(inst => {
-                                try {
+                            failedInstaller.ForEach(inst =>
+                            {
+                                try
+                                {
                                     inst.Display.Close();
                                 }
-                                catch 
+                                catch
                                 {
                                     //ignored
                                 }
@@ -148,7 +161,7 @@ namespace RainbowMage.OverlayPlugin.Updater
                             //Stored for closing window
                             failedInstaller.Add(installer);
                         }
-                       
+
                     }
                     catch
                     {

--- a/OverlayPlugin.Updater/CefInstaller.cs
+++ b/OverlayPlugin.Updater/CefInstaller.cs
@@ -81,9 +81,9 @@ namespace RainbowMage.OverlayPlugin.Updater
                         }
                         else if (
                             //Check cef sharp version
-                            (name.StartsWith("CefSharp") && !FileVersionInfo.GetVersionInfo(filePath).FileVersion.Equals(CEF_VERSION))
+                            (name.StartsWith("CefSharp") && !EnsureVersion(filePath, CEF_VERSION))
                             //Check cef redist version
-                            || (name.Equals("libcef.dll") && !FileVersionInfo.GetVersionInfo(filePath).FileVersion.Equals(CEF_REDIST_VERSION))
+                            || (name.Equals("libcef.dll") && !EnsureVersion(filePath, CEF_REDIST_VERSION))
                             )
                         {
                             itsFine = false;
@@ -96,6 +96,12 @@ namespace RainbowMage.OverlayPlugin.Updater
             }
 
             return await InstallCef(cefPath);
+        }
+
+        private static bool EnsureVersion(string filePath, string expect)
+        {
+            var info = FileVersionInfo.GetVersionInfo(filePath);
+            return $"{info.FileMajorPart}.{info.FileMinorPart}.{info.FileBuildPart}".Equals(expect);
         }
 
         public static async Task<bool> InstallCef(string cefPath, string archivePath = null)

--- a/OverlayPlugin/PluginLoader.cs
+++ b/OverlayPlugin/PluginLoader.cs
@@ -108,20 +108,38 @@ namespace RainbowMage.OverlayPlugin
                 if (SanityChecker.LoadSaneAssembly("HtmlRenderer"))
                 {
                     // Since this is an async method, we could have switched threds. Make sure InitPlugin() runs on the ACT main thread.
-                    ActGlobals.oFormActMain.Invoke((Action)(() =>
+                    ActGlobals.oFormActMain.Invoke((Action)(async () =>
                     {
                         try { 
                             pluginMain.InitPlugin(pluginScreenSpace, pluginStatusText);
                             initFailed = false;
-                        } catch (Exception ex)
+                        }
+                        catch (Exception ex)
                         {
+                            if (ex is TypeLoadException)
+                            {
+                                if (ex.Message.Contains("CefSharp"))
+                                {
+                                    //Cef load failed, try to repair cef
+                                    await CefInstaller.InstallCef(GetCefPath());
+                                    try
+                                    {
+                                        pluginMain.InitPlugin(pluginScreenSpace, pluginStatusText);
+                                    }
+                                    catch (Exception ex2)
+                                    {
+                                        //Still failed, showing message to users
+                                        ex = ex2;
+                                    }
+                                }
+                            }
                             // TODO: Add a log box to CefMissingTab and while CEF missing is the most likely
                             // cause for an exception here, it is not necessarily the case.
                             // logger.Log(LogLevel.Error, "Failed to init plugin: " + ex.ToString());
-                            
+
                             initFailed = true;
 
-                            MessageBox.Show("Failed to init OverlayPlugin: " + ex.ToString(), "OverlayPlugin Error");
+                            MessageBox.Show("加载ngld悬浮窗插件失败: " + ex.ToString(), "ngld悬浮窗插件错误");
                             pluginScreenSpace.Controls.Add(new CefMissingTab(GetCefPath(), this, container));
                         }
                     }));

--- a/OverlayPlugin/PluginLoader.cs
+++ b/OverlayPlugin/PluginLoader.cs
@@ -108,7 +108,7 @@ namespace RainbowMage.OverlayPlugin
                 if (SanityChecker.LoadSaneAssembly("HtmlRenderer"))
                 {
                     // Since this is an async method, we could have switched threds. Make sure InitPlugin() runs on the ACT main thread.
-                    ActGlobals.oFormActMain.Invoke((Action)(async () =>
+                    ActGlobals.oFormActMain.Invoke((Action)(() =>
                     {
                         try { 
                             pluginMain.InitPlugin(pluginScreenSpace, pluginStatusText);
@@ -121,7 +121,7 @@ namespace RainbowMage.OverlayPlugin
                                 if (ex.Message.Contains("CefSharp"))
                                 {
                                     //Cef load failed, try to repair cef
-                                    await CefInstaller.InstallCef(GetCefPath());
+                                    Task.Run(()=>CefInstaller.InstallCef(GetCefPath())).Wait();
                                     try
                                     {
                                         pluginMain.InitPlugin(pluginScreenSpace, pluginStatusText);

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -2,5 +2,5 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("22.8.9.2")]
-[assembly: AssemblyFileVersion("22.8.9.2")]
+[assembly: AssemblyVersion("22.8.9.3")]
+[assembly: AssemblyFileVersion("22.8.9.3")]


### PR DESCRIPTION
Due to the hotfix of 6.1, the CE opcode update may be required, so this PR is drafted.