### PR TITLE
fix: SkillDisplay and amethyst presets

### DIFF
--- a/OverlayPlugin.Core/resources/presets.json
+++ b/OverlayPlugin.Core/resources/presets.json
@@ -57,13 +57,13 @@
     "type": "MiniParse",
     "url": "https://overlays.ffcafe.cn/amethyst/",
     "size": [ 600, 500 ],
-    "supports": [ "legacy", "actws" ]
+    "supports": [ "actws" ]
   },
   "SkillDisplay 循环显示": {
     "type": "MiniParse",
     "url": "https://overlays.ffcafe.cn/SkillDisplay/",
     "size": [ 600, 500 ],
-    "supports": [ "legacy", "actws" ]
+    "supports": [ "actws" ]
   },
   "Skyline 横板悬浮窗": {
     "type": "MiniParse",


### PR DESCRIPTION
actws only auto enabled when supports option only have actws value